### PR TITLE
Fix live stream detection logic when URLs contain tracking parameters

### DIFF
--- a/ihatelivehime.user.js
+++ b/ihatelivehime.user.js
@@ -151,7 +151,7 @@
 		alert("操作成功");
 	}
 
-	let path_room_id = /^\/(\d+)$/.exec(document.location.pathname)
+	let path_room_id = /^\/(\d+)/.exec(document.location.pathname)
 
 	if (path_room_id === null) {
 		console.log("当前页面并非直播间！");


### PR DESCRIPTION
When the URL contains tracking parameters, the script will consider the current page not a live stream page.